### PR TITLE
When filtering for tasks, only display incomplete tasks

### DIFF
--- a/app/assets/stylesheets/entries.scss
+++ b/app/assets/stylesheets/entries.scss
@@ -2,6 +2,16 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+// when we display-todos-only we can end up with multiple uls next to each
+// other. normally, we want a margin between them, because they represent diff
+// lists. but in display-todos-only this distinction is eroded, and visually
+// they are presented as if they were all in the same list.
+// so for this special case we strip out the margin, unless it's the last child
+.entry-box .display-todos-only ul:not(:last-child) {
+  margin-bottom: 0px;
+}
+
+// TODO: this is unused, yeah?
 #entry_content {
   border: 1px grey solid;
   width: 100%;

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -30,7 +30,6 @@ class TimelineController < ApplicationController
         e.occurred_date
       end
 
-      @has_todo = !!@search_query.index("has:todo")
       @display_todos_only = !!@search_query.index("only:todo")
 
       @search_tokens = search.tokens

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -31,6 +31,7 @@ class TimelineController < ApplicationController
       end
 
       @has_todo = !!@search_query.index("has:todo")
+      @display_todos_only = !!@search_query.index("only:todo")
 
       @search_tokens = search.tokens
 

--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -2,7 +2,7 @@ module TimelineHelper
   def truncate_class(entry_body, collapsed = false)
     if collapsed
       if (entry_body&.size || 0) > 220
-      "truncate truncate-more"
+        "truncate truncate-more"
       else
         ""
       end

--- a/app/models/entry_renderer.rb
+++ b/app/models/entry_renderer.rb
@@ -137,12 +137,12 @@ class EntryRenderer
 
   SAFE_PIPELINE = HTML::Pipeline.new [
     PipelineFilter::MarkdownFilter, # convert to HTML
-    PipelineFilter::SubjectExtractorFilter,
     PipelineFilter::WikiLinkFilter,
     HTML::Pipeline::SanitizationFilter, # strip scary tags
     PipelineFilter::MyTaskListFilter, # convert task markdown to html
     PipelineFilter::HashtagFilter, # link hashtags
     PipelineFilter::MentionFilter, # link mentions
+    PipelineFilter::SubjectExtractorFilter, # TODO: does it matter if we extract the subject before or after the hash & mention filter? this could mess stuff up in static mode (i.e. the unsafe pipeline)
     PipelineFilter::TableOfContentsFilter, # ids to headers, toc tag
     HTML::Pipeline::ImageMaxWidthFilter, # max 100% for imgs
   ], { unsafe: true,

--- a/app/models/pipeline_filter/subject_extractor_filter.rb
+++ b/app/models/pipeline_filter/subject_extractor_filter.rb
@@ -3,7 +3,7 @@ class PipelineFilter::SubjectExtractorFilter < HTML::Pipeline::Filter
     subject = doc.children[0..3].css("h1, h2").first
 
     if subject
-      result[:entry_subject] = subject.text
+      result[:entry_subject] = subject.text.strip
       result[:entry_subject_html] = subject.to_s
       if context[:remove_subject]
         subject.remove

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -16,7 +16,8 @@ class Search
     "hide:true",
     "sort:asc",
     "sort:created",
-    "sort:created-asc"
+    "sort:created-asc",
+    "only:todo"
   ])
 
   OPERATORS = [
@@ -89,6 +90,8 @@ class Search
                     sql_query.where("kind is not null")
                   when "sort:asc"
                     sql_query.reorder(occurred_at: :asc)
+                  else
+                    sql_query
                   end
     end
 

--- a/app/views/entries/_list_entry.html.erb
+++ b/app/views/entries/_list_entry.html.erb
@@ -5,5 +5,5 @@
 <% elsif entry.bookmark? %>
   <%= render "entries/kinds/pinboard", entry: entry %>
 <% else %>
-  <%= render "entries/kinds/default", entry: entry, threaded: threaded %>
+  <%= render "entries/kinds/default", entry: entry, threaded: threaded, display_todos_only: local_assigns[:display_todos_only] %>
 <% end %>

--- a/app/views/entries/kinds/_default.html.erb
+++ b/app/views/entries/kinds/_default.html.erb
@@ -1,5 +1,5 @@
 <% entry_renderer = EntryRenderer.new(entry) %>
-<% if @has_todo %>
+<% if local_assigns[:display_todos_only] %>
   <% entry_body = entry_renderer.todo_to_html %>
 <% else %>
   <% entry_body = entry_renderer.to_html %>

--- a/app/views/entries/kinds/_default.html.erb
+++ b/app/views/entries/kinds/_default.html.erb
@@ -5,13 +5,15 @@
   <% entry_body = entry_renderer.to_html %>
 <% end %>
 
-<% entry_truncate_classes = nil %>
-<% if !local_assigns[:display_todos_only] %>
-  <% entry_truncate_classes = truncate_class(entry.body, threaded)%>
+<% entry_css_classes = nil %>
+<% if local_assigns[:display_todos_only] %>
+  <% entry_css_classes = "display-todos-only" %>
+<% else %>
+  <% entry_css_classes = truncate_class(entry.body, threaded) %>
 <% end %>
 
 <div class="entry-box <%= "entry-threaded" if threaded %>">
-  <div class="Box-body markdown-body <%= entry_truncate_classes %> js-task-list-container pb-1 ">
+  <div class="Box-body markdown-body js-task-list-container pb-1 <%= entry_css_classes %> ">
     <%= render partial: "entries/action_bar", locals: { entry: entry, threaded: threaded } %>
     <div class="entry-body">
       <% if local_assigns[:display_todos_only] %>

--- a/app/views/entries/kinds/_default.html.erb
+++ b/app/views/entries/kinds/_default.html.erb
@@ -1,13 +1,22 @@
+<% entry_renderer = EntryRenderer.new(entry) %>
 <% if @has_todo %>
-  <% entry_body = EntryRenderer.new(entry).todo_to_html %>
+  <% entry_body = entry_renderer.todo_to_html %>
 <% else %>
-  <% entry_body = EntryRenderer.new(entry).to_html %>
+  <% entry_body = entry_renderer.to_html %>
+<% end %>
+
+<% entry_truncate_classes = nil %>
+<% if !local_assigns[:display_todos_only] %>
+  <% entry_truncate_classes = truncate_class(entry.body, threaded)%>
 <% end %>
 
 <div class="entry-box <%= "entry-threaded" if threaded %>">
-  <div class="Box-body markdown-body <%= truncate_class(entry.body, threaded)%> <%= "truncate-more" if threaded %> js-task-list-container pb-1 ">
+  <div class="Box-body markdown-body <%= entry_truncate_classes %> js-task-list-container pb-1 ">
     <%= render partial: "entries/action_bar", locals: { entry: entry, threaded: threaded } %>
     <div class="entry-body">
+      <% if local_assigns[:display_todos_only] %>
+        <%= entry_renderer.subject_html %>
+      <% end %>
       <% if @search_tokens %>
         <%= highlight entry_body, @search_tokens, sanitize: false%>
       <% else %>

--- a/app/views/shared/_tabnav.html.erb
+++ b/app/views/shared/_tabnav.html.erb
@@ -1,14 +1,8 @@
-<% if true #FeatureFlag[:redesign] %>
-  <div class="tabnav mt-2">
-    <nav class="tabnav-tabs" aria-label="Foo bar">
-        <!-- <a href="<%= new_entry_path(notebook: @current_notebook) %>" class="btn btn&#45;sm float&#45;right"><%= octicon "pencil" %> New Entry</a> -->
-      
-      <!-- <a class="btn btn&#45;sm float&#45;right" href="#url" role="button">New Entry</a> -->
-
-      <a class="tabnav-tab" href="<%= timeline_path(notebook: @current_notebook) %>" <%= current_tabnav(:timeline) %> accesskey="1"><h5><%= octicon "note" %> Everything <span class="Counter">1</span></h5></a>
-      <a class="tabnav-tab" href="<%= agenda_path(notebook: @current_notebook) %>" <%= current_tabnav(:this_day) %> accesskey="2"><%= octicon "watch" %> This Day <span class="Counter">2</span></a>
-      <a class="tabnav-tab" href="<%= calendar_weekly_path(notebook: @current_notebook) %>"  <%= current_tabnav(:this_week) %>><%= octicon "list-unordered" %> This Week <span class="Counter">3</span></a>
-      <a class="tabnav-tab" href="<%= calendar_path(notebook: @current_notebook) %>" <%= current_tabnav(:this_month) %>><%= octicon "calendar" %> This Month <span class="Counter">4</span></a>
-    </nav>
-  </div>
-<% end %>
+<div class="tabnav mt-2">
+  <nav class="tabnav-tabs" aria-label="Foo bar">
+    <a class="tabnav-tab" href="<%= timeline_path(notebook: @current_notebook) %>" <%= current_tabnav(:timeline) %> accesskey="1"><h5><%= octicon "note" %> Everything <span class="Counter">1</span></h5></a>
+    <a class="tabnav-tab" href="<%= agenda_path(notebook: @current_notebook) %>" <%= current_tabnav(:this_day) %> accesskey="2"><%= octicon "watch" %> This Day <span class="Counter">2</span></a>
+    <a class="tabnav-tab" href="<%= calendar_weekly_path(notebook: @current_notebook) %>"  <%= current_tabnav(:this_week) %>><%= octicon "list-unordered" %> This Week <span class="Counter">3</span></a>
+    <a class="tabnav-tab" href="<%= calendar_path(notebook: @current_notebook) %>" <%= current_tabnav(:this_month) %>><%= octicon "calendar" %> This Month <span class="Counter">4</span></a>
+  </nav>
+</div>

--- a/app/views/timeline/_search_bar.html.erb
+++ b/app/views/timeline/_search_bar.html.erb
@@ -43,7 +43,7 @@
       </a>
 
       <% [
-          ["Tasks", "checklist", "has:todo"],
+          ["Tasks", "checklist", "has:todo only:todo"],
           ["Bookmarks", "bookmark", "is:bookmark"],
           #["Calendar", "calendar", "is:calendar"],
           #["Everything", "zap", "is:everything", "hide-sm"],

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -31,7 +31,7 @@
           <h3><a href="<%= calendar_daily_path(day, @current_notebook)%>"><%= day.strftime("%A, %Y-%m-%d") %></a></h3>
         </div>
         <% entries.each do |entry| %>
-          <%= render partial: "entries/list_entry", locals: { entry: entry } %>
+          <%= render partial: "entries/list_entry", locals: { entry: entry, display_todos_only: @display_todos_only } %>
         <% end %>
       </div>
 

--- a/test/migrations/migrate_to_thread_identifier_test.rb
+++ b/test/migrations/migrate_to_thread_identifier_test.rb
@@ -46,6 +46,9 @@ class MigrateToThreadIdentifierTest < ActiveSupport::TestCase
 
       assert_equal e1.identifier, e4.thread_identifier
       assert_equal e3.identifier, e4.in_reply_to
+
+      # restore callback
+      Entry.set_callback(:save, :set_thread_identifier)
     end
   end
 end

--- a/test/models/entry_renderer_test.rb
+++ b/test/models/entry_renderer_test.rb
@@ -151,17 +151,14 @@ class EntryRendererTest < ActiveSupport::TestCase
     FOO
     only_todo_html = @renderer.render_html(only_todo, todo_only: true)
 
-    # keeps first line, foo
-    # but discards second line, bar, and line after the task
-    # otherwise, renders a full ul[data-sourcepos].task-list etc
-
-    assert_equal "<p data-sourcepos=\"1:1-1:3\">foo</p>\n\n<ul data-sourcepos=\"5:1-6:0\" class=\"task-list\"><li data-sourcepos=\"5:1-6:0\" class=\"task-list-item\">\n<input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled> test task</li></ul>\n", only_todo_html
+    # deletes everything except the todo list:
+    assert_equal "\n\n<ul data-sourcepos=\"5:1-6:0\" class=\"task-list\"><li data-sourcepos=\"5:1-6:0\" class=\"task-list-item\">\n<input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled> test task</li></ul>\n", only_todo_html
 
 
     nested_list_example = <<~FOO
-    - this is a list, and should be kept because
+    - this is a list, but this item will be deleted
     - [ ] it has a nested task
-    - this item will also be kept cos its li is attached to the ul with the nested task
+    - this item will also deleted but the above nested task will be kept
 
 
     different text
@@ -170,7 +167,7 @@ class EntryRendererTest < ActiveSupport::TestCase
 
     nested_list_html = @renderer.render_html(nested_list_example, todo_only: true)
 
-    assert_equal "<ul data-sourcepos=\"1:1-5:0\" class=\"task-list\">\n<li data-sourcepos=\"1:1-1:44\">this is a list, and should be kept because</li>\n<li data-sourcepos=\"2:1-2:26\" class=\"task-list-item\">\n<input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled> it has a nested task</li>\n<li data-sourcepos=\"3:1-5:0\">this item will also be kept cos its li is attached to the ul with the nested task</li>\n</ul>\n\n", nested_list_html
+    assert_equal "<ul data-sourcepos=\"1:1-5:0\" class=\"task-list\"><li data-sourcepos=\"2:1-2:26\" class=\"task-list-item\">\n<input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled> it has a nested task</li></ul>\n\n", nested_list_html
 
     # TODO: MyTaskListFilter has a lot of branching
     # for so little testing; need to follow up with more


### PR DESCRIPTION
Decided I'd try a pull request instead of just git merging yolo.

With this set of changes I'm experimenting with changing how tasks are displayed. I decided that I only wanted to see _incomplete_ tasks, to make it easier to browse thru what I needed to accomplish.

Random list of changes:
- added new `only:todo` filter. `has:todo` now won't automatically delete non-tasks from the renderer, but will behave more like a normal filter option.
  - to do this i modified the upstream todo filter to optionally delete completed tasks
- before when filtering out list items i used to skip over the first line, which typically is where i write a "subject" for the note
  - but this ran into an edge case (i.e. notes without subjects, only list items)
  - so instead i now render the subject header instead of assuming the first line is special.
- but because of the order in which the subject extractor runs this was not rendering #hashes embedded in subject
  - so i changed in the order in which the subject extractor is executed,
  - tho i worry this might mess up static view stuff 😓 
- made it so todo-only entries don't get truncated with a "read more" button