### PR TITLE
Add build provenance

### DIFF
--- a/.github/workflows/publish_container.yaml
+++ b/.github/workflows/publish_container.yaml
@@ -1,6 +1,11 @@
 # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio
 name: Create and publish a Docker image
 
+permissions:
+  id-token: write
+  contents: write
+  packages: write
+
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
@@ -59,6 +64,7 @@ jobs:
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
+        id: build-push-latest
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -68,6 +74,11 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Attest image
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build-push-latest.outputs.digest }}
       - name: Extract metadata (tags, labels) for dev image
         id: meta2
         uses: docker/metadata-action@v5
@@ -79,6 +90,7 @@ jobs:
             type=ref,event=branch
             type=sha,format=long
       - name: Build and push dev image
+        id: build-push-development
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -87,6 +99,10 @@ jobs:
           tags: ${{ steps.meta2.outputs.tags }}
           labels: ${{ steps.meta2.outputs.labels }}
           annotations: ${{ steps.meta2.outputs.annotations }}
-
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Attest dev image
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-development
+          subject-digest: ${{ steps.build-push-development.outputs.digest }}


### PR DESCRIPTION
When container images are built & pushed, we should also sign them!, so the provenance of these images be verified prior to use.